### PR TITLE
Change capitalization of `metaData` to `metadata`

### DIFF
--- a/src/main/java/me/lucko/luckperms/extension/rest/bind/GroupSerializer.java
+++ b/src/main/java/me/lucko/luckperms/extension/rest/bind/GroupSerializer.java
@@ -43,7 +43,7 @@ public class GroupSerializer extends JsonSerializer<Group> {
         gen.writePOJO(Model.from(value));
     }
 
-    record Model(String name, String displayName, int weight, Collection<Node> nodes, CachedMetaData metaData) {
+    record Model(String name, String displayName, int weight, Collection<Node> nodes, CachedMetaData metadata) {
         static Model from(Group group) {
             return new Model(
                     group.getName(),

--- a/src/main/java/me/lucko/luckperms/extension/rest/bind/UserSerializer.java
+++ b/src/main/java/me/lucko/luckperms/extension/rest/bind/UserSerializer.java
@@ -48,7 +48,7 @@ public class UserSerializer extends JsonSerializer<User> {
         gen.writePOJO(Model.from(value));
     }
 
-    record Model(UUID uniqueId, String username, List<String> parentGroups, Collection<Node> nodes, CachedMetaData metaData) {
+    record Model(UUID uniqueId, String username, List<String> parentGroups, Collection<Node> nodes, CachedMetaData metadata) {
         static Model from(User user) {
             return new Model(
                     user.getUniqueId(),


### PR DESCRIPTION
Relevant in Users and Groups. The java serialization uses the name `metaData`, which is the key used in the JSON structure, however the swagger examples use `metadata`, which are technically invalid examples, because case matters