### PR TITLE
feature: Add a `replace` parameter for single node additions

### DIFF
--- a/src/main/java/me/lucko/luckperms/extension/rest/util/ParamUtils.java
+++ b/src/main/java/me/lucko/luckperms/extension/rest/util/ParamUtils.java
@@ -47,4 +47,18 @@ public final class ParamUtils {
             return objectMapper.readValue("\"" + string + "\"", TemporaryNodeMergeStrategy.class);
         }
     }
+
+    public static boolean readBoolean(Context ctx, String name, boolean defaultIfMissing) {
+        final String string = ctx.queryParam(name);
+
+        if (string == null) {
+            return defaultIfMissing;
+        } else if (string.equals("true")) {
+            return true;
+        } else if (string.equals("false")) {
+            return false;
+        } else {
+            throw new IllegalArgumentException("invalid boolean '" + string + "' for query param '" + name + "'");
+        }
+    }
 }

--- a/src/main/resources/luckperms-openapi.yml
+++ b/src/main/resources/luckperms-openapi.yml
@@ -323,6 +323,7 @@ paths:
       operationId: add-user-node
       parameters:
         - $ref: '#/components/parameters/temporaryNodeMergeStrategy'
+        - $ref: '#/components/parameters/replace'
       responses:
         '200':
           description: Ok - returns the updated nodes
@@ -862,6 +863,7 @@ paths:
       operationId: add-group-node
       parameters:
         - $ref: '#/components/parameters/temporaryNodeMergeStrategy'
+        - $ref: '#/components/parameters/replace'
       responses:
         '200':
           description: Ok - returns the updated nodes
@@ -1848,5 +1850,12 @@ components:
         $ref: '#/components/schemas/TemporaryNodeMergeStrategy'
       required: false
       description: The node merge strategy
+    replace:
+      name: replace
+      in: query
+      schema:
+        type: boolean
+      required: false
+      description: If the node should replace an existing node with the same key (delete and add)
 security:
   - apikey: []


### PR DESCRIPTION
This provides an "atomic" way of performing a replacement on a node without having to make two separate rest calls.

Unsure if there is potentially a better solution, or more value in having a `/replace` endpoint with a parameter to pick the equality predicate. However, I think this is good as a nice addition for atomic remove/add for most use cases now.